### PR TITLE
Intégration ingestion automatique des logs SSH + dashboard 24h (Chart.js)

### DIFF
--- a/App/Controller/Listener.php
+++ b/App/Controller/Listener.php
@@ -12,6 +12,7 @@ use \App\Library\EngineV4;
 use \Glial\Sgbd\Sgbd;
 use \App\Library\Extraction;
 use \App\Library\Extraction2;
+use \App\Library\LogIngestionManager;
 
 
 
@@ -199,6 +200,9 @@ class Listener extends Controller
                 Digest::integrate([$arr['id_mysql_server'],$arr['min_date'] ]);
                 break;
 
+            case "ssh_stats":
+                LogIngestionManager::collectForServer((int) $arr['id_mysql_server']);
+                break;
 
             default:
 

--- a/App/Controller/LogIngestion.php
+++ b/App/Controller/LogIngestion.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Controller;
+
+use \Glial\Synapse\Controller;
+use \Glial\Sgbd\Sgbd;
+use \App\Library\LogIngestionManager;
+
+class LogIngestion extends Controller
+{
+    public function collect($param)
+    {
+        $this->view = false;
+
+        if (! empty($param[0])) {
+            LogIngestionManager::collectForServer((int) $param[0]);
+            return;
+        }
+
+        LogIngestionManager::collectAll();
+    }
+
+    public function dashboard24h($param)
+    {
+        $db = Sgbd::sql(DB_DEFAULT);
+
+        $id_mysql_server = ! empty($param[0]) ? (int) $param[0] : 0;
+
+        if (empty($id_mysql_server)) {
+            $sql = "SELECT id FROM mysql_server ORDER BY id ASC LIMIT 1";
+            $res = $db->sql_query($sql);
+            while ($ob = $db->sql_fetch_object($res)) {
+                $id_mysql_server = (int) $ob->id;
+            }
+        }
+
+        $this->di['js']->addJavascript(array('chart.min.js'));
+
+        $sql = "SELECT DATE_FORMAT(event_date, '%Y-%m-%d %H:00:00') AS bucket_hour, level, SUM(count_seen) AS total\n                FROM ssh_log_event\n                WHERE id_mysql_server = ".$id_mysql_server."\n                AND event_date >= DATE_SUB(NOW(), INTERVAL 24 HOUR)\n                GROUP BY 1,2\n                ORDER BY 1 ASC";
+
+        $res = $db->sql_query($sql);
+
+        $series = array();
+        while ($row = $db->sql_fetch_array($res, MYSQLI_ASSOC)) {
+            $series[] = $row;
+        }
+
+        $data = array();
+        $data['id_mysql_server'] = $id_mysql_server;
+        $data['series'] = $series;
+
+        $this->set('data', $data);
+    }
+}

--- a/App/Library/LogIngestionManager.php
+++ b/App/Library/LogIngestionManager.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Library;
+
+use \Glial\Sgbd\Sgbd;
+
+class LogIngestionManager
+{
+    const DEFAULT_TAIL_LINES = 600;
+
+    public static function collectForServer($id_mysql_server)
+    {
+        $db = Sgbd::sql(DB_DEFAULT);
+
+        $sql = "SELECT id, id_mysql_server, log_path, last_inode, last_mtime, is_active
+                FROM ssh_log_watch
+                WHERE id_mysql_server = ".(int) $id_mysql_server." AND is_active = 1";
+        $res = $db->sql_query($sql);
+
+        while ($watch = $db->sql_fetch_array($res, MYSQLI_ASSOC)) {
+            self::collectWatch($watch);
+        }
+    }
+
+    public static function collectAll()
+    {
+        $db = Sgbd::sql(DB_DEFAULT);
+
+        $sql = "SELECT id, id_mysql_server, log_path, last_inode, last_mtime, is_active
+                FROM ssh_log_watch
+                WHERE is_active = 1";
+        $res = $db->sql_query($sql);
+
+        while ($watch = $db->sql_fetch_array($res, MYSQLI_ASSOC)) {
+            self::collectWatch($watch);
+        }
+    }
+
+    public static function collectWatch($watch)
+    {
+        $ssh = Ssh::ssh((int) $watch['id_mysql_server']);
+
+        if (empty($ssh) || $ssh === false) {
+            return;
+        }
+
+        $path = escapeshellarg($watch['log_path']);
+        $stat = trim($ssh->exec("stat -c '%i|%Y' ".$path." 2>/dev/null"));
+
+        if (empty($stat) || strpos($stat, '|') === false) {
+            $ssh->disconnect();
+            return;
+        }
+
+        list($inode, $mtime) = explode('|', $stat);
+
+        $has_change = ((string) $watch['last_inode'] !== (string) $inode)
+            || ((string) $watch['last_mtime'] !== (string) $mtime);
+
+        if (! $has_change) {
+            $ssh->disconnect();
+            return;
+        }
+
+        $raw_lines = trim($ssh->exec("tail -n ".self::DEFAULT_TAIL_LINES." ".$path." 2>/dev/null"));
+        $ssh->disconnect();
+
+        if (empty($raw_lines)) {
+            self::updateWatch((int) $watch['id'], $inode, $mtime);
+            return;
+        }
+
+        $lines = preg_split('/\r\n|\r|\n/', $raw_lines);
+
+        foreach ($lines as $line) {
+            $parsed = self::parseLine($line);
+            if ($parsed === false) {
+                continue;
+            }
+
+            self::storeEvent((int) $watch['id'], (int) $watch['id_mysql_server'], $parsed);
+        }
+
+        self::updateWatch((int) $watch['id'], $inode, $mtime);
+    }
+
+    public static function parseLine($line)
+    {
+        $line = trim((string) $line);
+
+        if ($line === '') {
+            return false;
+        }
+
+        $event_date = date('Y-m-d H:i:s');
+        $level = 'INFO';
+
+        if (preg_match('/^([A-Z][a-z]{2}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+/', $line, $matches)) {
+            $candidate = date('Y')." ".$matches[1];
+            $timestamp = strtotime($candidate);
+            if ($timestamp !== false) {
+                $event_date = date('Y-m-d H:i:s', $timestamp);
+            }
+        }
+
+        if (preg_match('/\b(DEBUG|INFO|NOTICE|WARN|WARNING|ERROR|CRITICAL|ALERT|EMERGENCY)\b/i', $line, $matches)) {
+            $candidate = strtoupper($matches[1]);
+            if ($candidate === 'WARN') {
+                $candidate = 'WARNING';
+            }
+            $level = $candidate;
+        }
+
+        $normalized = preg_replace('/\d+/', '?', strtolower($line));
+
+        return array(
+            'event_date' => $event_date,
+            'level' => $level,
+            'message' => $line,
+            'message_hash' => sha1($normalized),
+        );
+    }
+
+    private static function storeEvent($id_watch, $id_mysql_server, $parsed)
+    {
+        $db = Sgbd::sql(DB_DEFAULT);
+
+        $event_date = $db->sql_real_escape_string($parsed['event_date']);
+        $bucket_minute = $db->sql_real_escape_string(substr($parsed['event_date'], 0, 16).':00');
+        $level = $db->sql_real_escape_string($parsed['level']);
+        $message = $db->sql_real_escape_string(substr($parsed['message'], 0, 4096));
+        $hash = $db->sql_real_escape_string($parsed['message_hash']);
+
+        $sql = "INSERT INTO ssh_log_event (`id_ssh_log_watch`,`id_mysql_server`,`event_date`,`bucket_minute`,`level`,`message`,`message_hash`,`count_seen`,`date_created`,`date_updated`)\n                VALUES (".(int) $id_watch.",".(int) $id_mysql_server.",'".$event_date."','".$bucket_minute."','".$level."','".$message."','".$hash."',1,NOW(),NOW())\n                ON DUPLICATE KEY UPDATE count_seen = count_seen + 1, event_date = VALUES(event_date), date_updated = NOW()";
+
+        $db->sql_query($sql);
+    }
+
+    private static function updateWatch($id_watch, $inode, $mtime)
+    {
+        $db = Sgbd::sql(DB_DEFAULT);
+
+        $sql = "UPDATE ssh_log_watch\n                SET last_inode='".$db->sql_real_escape_string((string) $inode)."',\n                    last_mtime='".$db->sql_real_escape_string((string) $mtime)."',\n                    date_last_collected = NOW()\n                WHERE id = ".(int) $id_watch;
+
+        $db->sql_query($sql);
+    }
+}

--- a/App/Patch/6f58c5f42b3a6b4fd5bf1eb1fbf4e2a79a2b1ef1.sql
+++ b/App/Patch/6f58c5f42b3a6b4fd5bf1eb1fbf4e2a79a2b1ef1.sql
@@ -1,0 +1,36 @@
+CREATE TABLE IF NOT EXISTS `ssh_log_watch` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id_mysql_server` int(11) NOT NULL,
+  `log_path` varchar(255) NOT NULL,
+  `last_inode` varchar(32) NOT NULL DEFAULT '',
+  `last_mtime` varchar(32) NOT NULL DEFAULT '',
+  `is_active` tinyint(1) NOT NULL DEFAULT 1,
+  `retention_days` int(11) NOT NULL DEFAULT 7,
+  `date_last_collected` datetime DEFAULT NULL,
+  `date_created` datetime NOT NULL DEFAULT current_timestamp(),
+  `date_updated` datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uniq_watch` (`id_mysql_server`,`log_path`),
+  KEY `idx_active` (`is_active`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE IF NOT EXISTS `ssh_log_event` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id_ssh_log_watch` int(11) NOT NULL,
+  `id_mysql_server` int(11) NOT NULL,
+  `event_date` datetime NOT NULL,
+  `bucket_minute` datetime NOT NULL,
+  `level` enum('DEBUG','INFO','NOTICE','WARNING','ERROR','CRITICAL','ALERT','EMERGENCY') NOT NULL DEFAULT 'INFO',
+  `message` varchar(4096) NOT NULL,
+  `message_hash` char(40) NOT NULL,
+  `count_seen` int(11) NOT NULL DEFAULT 1,
+  `date_created` datetime NOT NULL DEFAULT current_timestamp(),
+  `date_updated` datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uniq_event_smart_storage` (`id_ssh_log_watch`,`message_hash`,`bucket_minute`),
+  KEY `idx_dashboard` (`id_mysql_server`,`event_date`,`level`),
+  CONSTRAINT `ssh_log_event_ibfk_1` FOREIGN KEY (`id_ssh_log_watch`) REFERENCES `ssh_log_watch` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+INSERT IGNORE INTO `ssh_log_watch` (`id_mysql_server`,`log_path`)
+SELECT `id`, '/var/log/syslog' FROM `mysql_server`;

--- a/App/view/LogIngestion/dashboard24h.view.php
+++ b/App/view/LogIngestion/dashboard24h.view.php
@@ -1,0 +1,95 @@
+<?php
+
+$chart_id = 'log-ingestion-24h-'.uniqid();
+
+$labels = array();
+$levels = array('DEBUG', 'INFO', 'NOTICE', 'WARNING', 'ERROR', 'CRITICAL', 'ALERT', 'EMERGENCY');
+$matrix = array();
+
+foreach ($levels as $level) {
+    $matrix[$level] = array();
+}
+
+foreach ($data['series'] as $row) {
+    $labels[$row['bucket_hour']] = $row['bucket_hour'];
+}
+
+$labels = array_values($labels);
+
+foreach ($levels as $level) {
+    foreach ($labels as $label) {
+        $matrix[$level][$label] = 0;
+    }
+}
+
+foreach ($data['series'] as $row) {
+    $matrix[$row['level']][$row['bucket_hour']] = (int) $row['total'];
+}
+
+$datasets = array();
+$colors = array(
+    'DEBUG' => '#9E9E9E',
+    'INFO' => '#2196F3',
+    'NOTICE' => '#00BCD4',
+    'WARNING' => '#FFC107',
+    'ERROR' => '#F44336',
+    'CRITICAL' => '#E91E63',
+    'ALERT' => '#9C27B0',
+    'EMERGENCY' => '#000000',
+);
+
+foreach ($levels as $level) {
+    $datasets[] = array(
+        'label' => $level,
+        'data' => array_values($matrix[$level]),
+        'borderColor' => $colors[$level],
+        'backgroundColor' => $colors[$level],
+        'fill' => false,
+        'pointRadius' => 2,
+        'tension' => 0,
+    );
+}
+
+echo '<div class="panel panel-primary">';
+echo '<div class="panel-heading"><h3 class="panel-title">'.__('Automatic log ingestion (last 24h)').' #'.$data['id_mysql_server'].'</h3></div>';
+echo '<div class="panel-body">';
+echo '<canvas id="'.$chart_id.'" height="90"></canvas>';
+echo '</div>';
+echo '</div>';
+
+?>
+<script>
+(function () {
+    var ctx = document.getElementById(<?php echo json_encode($chart_id); ?>).getContext('2d');
+
+    new Chart(ctx, {
+        type: 'line',
+        data: {
+            labels: <?php echo json_encode($labels); ?>,
+            datasets: <?php echo json_encode($datasets); ?>
+        },
+        options: {
+            responsive: true,
+            interaction: {
+                mode: 'index',
+                intersect: false
+            },
+            plugins: {
+                title: {
+                    display: true,
+                    text: '24h log flow (Kafka-like timeline)'
+                }
+            },
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    title: {
+                        display: true,
+                        text: 'events'
+                    }
+                }
+            }
+        }
+    });
+})();
+</script>


### PR DESCRIPTION
### Motivation
- Ajouter une ingestion automatique des logs accessibles par SSH, détecter les modifications de fichiers et stocker les événements de façon compacte pour analyse temporelle.
- Offrir une visualisation « Kafka-like » des dernières 24 heures par niveau de sévérité via `Chart.js` pour faciliter le suivi d’écoulement d’événements.

### Description
- Ajout d’un gestionnaire d’ingestion `App/Library/LogIngestionManager.php` qui se connecte en SSH, détecte `inode`/`mtime`, exécute `tail`, normalise la date/niveau, calcule un hash de message et stocke des événements dédupliqués par bucket minute.
- Nouveau contrôleur `App/Controller/LogIngestion.php` fournissant `collect` (collecte par serveur ou tous) et `dashboard24h` (agrège 24h pour l’UI) et intégration de `chart.min.js` pour l’affichage.
- Vue `App/view/LogIngestion/dashboard24h.view.php` : rendu `Chart.js` multi-séries par niveau (DEBUG → EMERGENCY) affichant une timeline horaire des 24 dernières heures.
- Patch SQL `App/Patch/6f58c5f4*.sql` créant `ssh_log_watch` (liste des fichiers surveillés et métadonnées) et `ssh_log_event` (stockage intelligent avec clé unique `(id_ssh_log_watch,message_hash,bucket_minute)`), et bootstrap d’un watch par défaut `/var/log/syslog` pour chaque serveur.
- Intégration dans le pipeline existant : `App/Controller/Listener.php` déclenche `LogIngestionManager::collectForServer()` lorsque `ssh_stats` est mis à jour afin de lancer la collecte de logs automatiquement.

### Testing
- Vérifications de syntaxe PHP effectuées avec `php -l` sur `App/Library/LogIngestionManager.php`, `App/Controller/LogIngestion.php`, `App/view/LogIngestion/dashboard24h.view.php` et `App/Controller/Listener.php` (toutes OK).
- Tentative de lancement de la suite PHPUnit `./vendor/bin/phpunit --testsuite "PmaControl Test Suite"` échouée car `vendor/`/`phpunit` manquent dans cet environnement.
- Tentative d’installation des dépendances `composer install --no-interaction` bloquée par un accès réseau à Packagist (`CONNECT tunnel failed, response 403`).
- Démarrage local du serveur PHP (`php -S 0.0.0.0:8080 -t App/Webroot`) et capture d’écran automatisée ; le bootstrap web échoue sans `configuration/webroot.config.php`, toutefois une capture du rendu d’erreur a été produite pour revue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2690a28748326bc445e9f0cdaf264)