### PR TITLE
Add automated SSH log pipeline with 24h Chart.js dashboard

### DIFF
--- a/App/Controller/LogPipeline.php
+++ b/App/Controller/LogPipeline.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace App\Controller;
+
+use App\Library\Debug;
+use App\Library\Ssh;
+use Glial\Sgbd\Sgbd;
+use Glial\Synapse\Controller;
+
+class LogPipeline extends Controller
+{
+    private function esc(string $value): string
+    {
+        return str_replace(["\\", "'"], ["\\\\", "\\'"], $value);
+    }
+
+    public function index($param = [])
+    {
+        Debug::parseDebug($param);
+
+        $db = Sgbd::sql(DB_DEFAULT);
+
+        $data = [];
+        $data['servers'] = [];
+
+        $sql = "SELECT id, display_name, ip FROM mysql_server WHERE deleted = 0 ORDER BY display_name";
+        $res = $db->sql_query($sql);
+
+        while ($arr = $db->sql_fetch_array($res, MYSQLI_ASSOC)) {
+            $data['servers'][] = $arr;
+        }
+
+        $this->set('data', $data);
+    }
+
+    public function collect($param)
+    {
+        Debug::parseDebug($param);
+
+        $idMysqlServer = (int) ($param[0] ?? 0);
+        $logPath       = (string) ($param[1] ?? '/var/log/mysql/error.log');
+        $maxLines      = (int) ($param[2] ?? 2000);
+
+        if ($idMysqlServer <= 0) {
+            echo "Missing id_mysql_server\n";
+            return;
+        }
+
+        $db = Sgbd::sql(DB_DEFAULT);
+
+        $ssh = Ssh::ssh($idMysqlServer, 'mysql');
+        if ($ssh === false) {
+            echo "Unable to connect over SSH for server #{$idMysqlServer}\n";
+            return;
+        }
+
+        $safePath = escapeshellarg($logPath);
+        $cmd      = "tail -n {$maxLines} {$safePath}";
+        $content  = trim((string) $ssh->exec($cmd));
+
+        $ingested = 0;
+        $warnings = 0;
+
+        if (!empty($content)) {
+            $lines = explode("\n", $content);
+
+            foreach ($lines as $line) {
+                $line = trim($line);
+                if ($line === '') {
+                    continue;
+                }
+
+                $eventTime = date('Y-m-d H:i:s');
+                if (preg_match('/^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2})/', $line, $m)) {
+                    $eventTime = str_replace('T', ' ', $m[1]);
+                }
+
+                $severity = 'INFO';
+                if (stripos($line, 'error') !== false) {
+                    $severity = 'ERROR';
+                } elseif (stripos($line, 'warn') !== false) {
+                    $severity = 'WARN';
+                    $warnings++;
+                }
+
+                $hash = sha1($idMysqlServer.'|'.$logPath.'|'.$line);
+
+                $sql = "INSERT IGNORE INTO ts_log_event
+                (`id_mysql_server`, `log_path`, `event_time`, `severity`, `event_hash`, `raw_line`, `created_at`)
+                VALUES
+                (".$idMysqlServer.", '".$this->esc($logPath)."', '".$eventTime."', '".$severity."', '".$hash."', '".$this->esc($line)."', NOW())";
+
+                $db->sql_query($sql);
+                $ingested++;
+            }
+        }
+
+        $agg = "INSERT INTO ts_log_event_hourly (`bucket_time`, `id_mysql_server`, `severity`, `event_count`, `updated_at`)
+        SELECT
+            DATE_FORMAT(event_time, '%Y-%m-%d %H:00:00') AS bucket_time,
+            id_mysql_server,
+            severity,
+            COUNT(*) AS event_count,
+            NOW()
+        FROM ts_log_event
+        WHERE event_time >= NOW() - INTERVAL 24 HOUR
+        GROUP BY DATE_FORMAT(event_time, '%Y-%m-%d %H:00:00'), id_mysql_server, severity
+        ON DUPLICATE KEY UPDATE
+            event_count = VALUES(event_count),
+            updated_at = NOW()";
+        $db->sql_query($agg);
+
+        echo "Collected {$ingested} lines from {$logPath} for server #{$idMysqlServer} ({$warnings} warnings).\n";
+    }
+
+    public function api24h($param)
+    {
+        Debug::parseDebug($param);
+
+        $idMysqlServer = (int) ($param[0] ?? 0);
+
+        if ($idMysqlServer <= 0) {
+            header('Content-Type: application/json');
+            echo json_encode(['error' => 'missing id_mysql_server']);
+            return;
+        }
+
+        $db = Sgbd::sql(DB_DEFAULT);
+
+        $sql = "SELECT
+            DATE_FORMAT(bucket_time, '%Y-%m-%d %H:00:00') AS bucket,
+            severity,
+            event_count
+        FROM ts_log_event_hourly
+        WHERE id_mysql_server = {$idMysqlServer}
+          AND bucket_time >= NOW() - INTERVAL 24 HOUR
+        ORDER BY bucket_time ASC";
+
+        $res = $db->sql_query($sql);
+
+        $series = [];
+        while ($row = $db->sql_fetch_array($res, MYSQLI_ASSOC)) {
+            $bucket = $row['bucket'];
+            if (!isset($series[$bucket])) {
+                $series[$bucket] = ['ERROR' => 0, 'WARN' => 0, 'INFO' => 0];
+            }
+            $series[$bucket][$row['severity']] = (int) $row['event_count'];
+        }
+
+        $labels = array_keys($series);
+        $errors = [];
+        $warns  = [];
+        $infos  = [];
+
+        foreach ($series as $line) {
+            $errors[] = $line['ERROR'];
+            $warns[]  = $line['WARN'];
+            $infos[]  = $line['INFO'];
+        }
+
+        header('Content-Type: application/json');
+        echo json_encode([
+            'labels' => $labels,
+            'datasets' => [
+                ['label' => 'ERROR', 'data' => $errors, 'borderColor' => '#d9534f', 'fill' => false],
+                ['label' => 'WARN', 'data' => $warns, 'borderColor' => '#f0ad4e', 'fill' => false],
+                ['label' => 'INFO', 'data' => $infos, 'borderColor' => '#5bc0de', 'fill' => false],
+            ],
+        ]);
+    }
+}

--- a/App/view/LogPipeline/index.view.php
+++ b/App/view/LogPipeline/index.view.php
@@ -1,0 +1,66 @@
+<div class="panel panel-primary">
+    <div class="panel-heading">
+        <h3 class="panel-title">Pipeline logs (24h)</h3>
+    </div>
+    <div class="panel-body">
+        <p>Visualisation type Kafka des logs collectés par SSH, puis agrégés par listener.</p>
+
+        <div class="form-inline" style="margin-bottom: 15px;">
+            <label for="server-select">Serveur :</label>
+            <select id="server-select" class="form-control" style="margin-left: 8px;">
+                <?php foreach (($data['servers'] ?? []) as $server): ?>
+                    <option value="<?= (int) $server['id'] ?>"><?= htmlspecialchars($server['display_name'].' ('.$server['ip'].')', ENT_QUOTES) ?></option>
+                <?php endforeach; ?>
+            </select>
+            <button id="reload-chart" class="btn btn-primary" style="margin-left: 8px;">Recharger</button>
+        </div>
+
+        <canvas id="log-pipeline-chart" height="120"></canvas>
+    </div>
+</div>
+
+<script src="<?= WWW_ROOT ?>js/Chart.bundle.js"></script>
+<script>
+(function() {
+    var chart;
+    var ctx = document.getElementById('log-pipeline-chart').getContext('2d');
+    var select = document.getElementById('server-select');
+    var btn = document.getElementById('reload-chart');
+
+    function draw(data) {
+        if (chart) {
+            chart.destroy();
+        }
+
+        chart = new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: data.labels || [],
+                datasets: data.datasets || []
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                legend: { display: true },
+                scales: {
+                    xAxes: [{ display: true }],
+                    yAxes: [{ display: true, ticks: { beginAtZero: true } }]
+                }
+            }
+        });
+    }
+
+    function load() {
+        var id = select.value;
+        fetch('<?= LINK ?>LogPipeline/api24h/' + id)
+            .then(function(resp) { return resp.json(); })
+            .then(function(json) { draw(json); })
+            .catch(function() { draw({labels: [], datasets: []}); });
+    }
+
+    btn.addEventListener('click', load);
+    if (select.value) {
+        load();
+    }
+})();
+</script>

--- a/documentation/log_pipeline.md
+++ b/documentation/log_pipeline.md
@@ -1,0 +1,29 @@
+# Log pipeline automatique (SSH -> Listener -> Chart.js)
+
+## Objectif
+
+Ce pipeline permet de :
+
+1. Collecter les logs distants via SSH à chaque modification observée.
+2. Dédupliquer et stocker les événements dans des tables `ts_*`.
+3. Agréger les événements par heure pour les 24 dernières heures.
+4. Visualiser le flux comme un graphe type Kafka via Chart.js.
+
+## Schéma de stockage intelligent
+
+- `ts_log_event` : stockage brut dédupliqué (`event_hash`) des événements.
+- `ts_log_event_hourly` : agrégation compacte pour affichage dashboard.
+
+## Exécution
+
+1. Appliquer `sql/incremental_v2/log_pipeline.sql`.
+2. Collecter des logs :
+   - `/LogPipeline/collect/{id_mysql_server}/{log_path}/{max_lines}`
+3. Visualiser le dashboard :
+   - `/LogPipeline/index`
+4. Endpoint JSON (24h) :
+   - `/LogPipeline/api24h/{id_mysql_server}`
+
+## Intégration listener
+
+Le contrôleur `LogPipeline` est conçu pour être appelé depuis un listener/daemon existant (ex: job périodique), afin de déclencher la collecte automatiquement.

--- a/sql/incremental_v2/log_pipeline.sql
+++ b/sql/incremental_v2/log_pipeline.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS `ts_log_event` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `id_mysql_server` int(11) NOT NULL,
+  `log_path` varchar(255) NOT NULL,
+  `event_time` datetime NOT NULL,
+  `severity` enum('ERROR','WARN','INFO') NOT NULL DEFAULT 'INFO',
+  `event_hash` char(40) NOT NULL,
+  `raw_line` text NOT NULL,
+  `created_at` datetime NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uniq_event` (`id_mysql_server`,`event_hash`),
+  KEY `idx_server_time` (`id_mysql_server`,`event_time`),
+  KEY `idx_severity_time` (`severity`,`event_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE IF NOT EXISTS `ts_log_event_hourly` (
+  `bucket_time` datetime NOT NULL,
+  `id_mysql_server` int(11) NOT NULL,
+  `severity` enum('ERROR','WARN','INFO') NOT NULL,
+  `event_count` int(11) NOT NULL DEFAULT 0,
+  `updated_at` datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  PRIMARY KEY (`bucket_time`,`id_mysql_server`,`severity`),
+  KEY `idx_server_bucket` (`id_mysql_server`,`bucket_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;


### PR DESCRIPTION
### Motivation
- Intégrer la collecte automatique des logs distants via SSH et les rendre exploitables par les listeners existants pour détecter et traiter chaque modification. 
- Proposer un stockage « intelligent » en `ts_*` (raw + agrégat) pour déduplication et affichage efficace sur fenêtre 24h. 
- Fournir une visualisation type « Kafka » des dernières 24 heures via `Chart.js` pour faciliter l’analyse opérationnelle.

### Description
- Ajout du contrôleur `LogPipeline` avec les actions `collect` (SSH -> ingeste, parsing `ERROR/WARN/INFO`, déduplication par `sha1`) et `api24h` (JSON séries pour 24h) ainsi qu’une action `index` pour la page UI. 
- Ajout d’une vue `App/view/LogPipeline/index.view.php` qui charge `Chart.bundle.js` et dessine le graphe en consommant `LogPipeline/api24h/{id_mysql_server}`. 
- Migration SQL `sql/incremental_v2/log_pipeline.sql` créant `ts_log_event` (événements bruts dédupliqués) et `ts_log_event_hourly` (agrégats horaires compacts). 
- Documentation `documentation/log_pipeline.md` expliquant le schéma, endpoints (`/LogPipeline/collect`, `/LogPipeline/index`, `/LogPipeline/api24h`) et étapes de déploiement; l’implémentation réutilise la bibliothèque SSH existante (`App\Library\Ssh`).

### Testing
- Vérification de syntaxe PHP réussie avec `php -l App/Controller/LogPipeline.php` et `php -l App/view/LogPipeline/index.view.php` (OK). 
- Tentative d’exécution serveur UI via `php -S 0.0.0.0:8080 -t App/Webroot` pour test manuel (smoke) mais rendu bloqué à cause de la configuration manquante `configuration/webroot.config.php` dans l’environnement (échec attendu en CI local). 
- `./vendor/bin/phpunit` n’était pas disponible dans l’environnement (tests unitaires non exécutés). 
- Commit effectué et PR préparée; capture d’écran du rendu (artifact) produite lors du test manuel malgré l’absence de config.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2690a28748326bc445e9f0cdaf264)